### PR TITLE
0.2.5

### DIFF
--- a/DMBotNetwork/__init__.py
+++ b/DMBotNetwork/__init__.py
@@ -4,4 +4,4 @@ from .main.utils.cl_unit import ClUnit
 from .main.utils.server_db import ServerDB
 
 __all__ = ["Client", "Server", "ClUnit", "ServerDB"]
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/DMBotNetwork/main/client.py
+++ b/DMBotNetwork/main/client.py
@@ -9,7 +9,7 @@ from typing import (Any, Dict, List, Optional, Type, Union, get_args,
                     get_origin, get_type_hints)
 
 import aiofiles
-
+import uuid
 from .utils import ResponseCode
 
 logger = logging.getLogger("DMBN:Client")
@@ -105,7 +105,10 @@ class Client:
         await cls.send_package(ResponseCode.NET_REQ, net_func_name=func_name, **kwargs)
 
     @classmethod
-    async def req_get_data(cls, func_name: str, get_key: str, **kwargs) -> Any:
+    async def req_get_data(cls, func_name: str, get_key: Optional[str], **kwargs) -> Any:
+        if get_key is None:
+            get_key = str(uuid.uuid4())
+            
         if get_key in cls._data_cache:
             return cls._data_cache.pop(get_key)
 

--- a/DMBotNetwork/main/client.py
+++ b/DMBotNetwork/main/client.py
@@ -82,7 +82,7 @@ class Client:
                     logger.error(
                         f"Type mismatch for argument '{arg_name}': expected {expected_type}, got {type(arg_value)}."
                     )
-                return
+                    return
 
         try:
             if inspect.iscoroutinefunction(func):

--- a/DMBotNetwork/main/client.py
+++ b/DMBotNetwork/main/client.py
@@ -3,13 +3,14 @@ import base64
 import inspect
 import json
 import logging
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import (Any, Dict, List, Optional, Type, Union, get_args,
                     get_origin, get_type_hints)
 
 import aiofiles
-import uuid
+
 from .utils import ResponseCode
 
 logger = logging.getLogger("DMBN:Client")

--- a/DMBotNetwork/main/server.py
+++ b/DMBotNetwork/main/server.py
@@ -72,7 +72,7 @@ class Server:
                     await cl_unit.send_log_error(
                         f"Type mismatch for argument '{arg_name}': expected {expected_type}, got {type(arg_value)}."
                     )
-                return
+                    return
 
         try:
             if inspect.iscoroutinefunction(func):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="DMBotNetwork",
-    version="0.2.4",
+    version="0.2.5",
     packages=find_packages(),
     install_requires=["aiosqlite", "aiofiles", "bcrypt", "msgpack"],
     author="Angels And Demons dev team",


### PR DESCRIPTION
- Исправлен баг с отступами при вызове функций, из-за чего при проверке типа функция просто не срабатывала
- Добавлена возможность установить в `Client.req_get_data()` значение `get_key` на `None` для генерации рандомного ключа